### PR TITLE
Incorporate use of mapStateToProps and mapDispatchToProps

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,4 @@
+{
+    "presets": ["react-app"],
+    "plugins": ["babel-plugin-transform-es2015-modules-commonjs", "transform-object-rest-spread"]
+  }

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,8 @@
+{
+    "extends": "react-app",
+    "parser": "babel-eslint",
+    "parserOptions": {
+      "sourceType": "module",
+      "allowImportExportEverywhere": true
+    }
+  }

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ This project was bootstrapped with [Create React App](https://github.com/faceboo
 
 You can find the most recent version of the guide [here](https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/template/README.md).
 
+**Testing Branch** : This is where i'll try break stuff.
+
 ---
 
 ###### Commands:

--- a/src/App.js
+++ b/src/App.js
@@ -21,7 +21,7 @@ class App extends Component {
     this.unsubscribe = store.subscribe(() =>
     console.log(store.getState())
     )
-    window.map = this;
+    window.App = this;
   }
   
   componentWillUnmount() {

--- a/src/components/FileHandler.js
+++ b/src/components/FileHandler.js
@@ -84,7 +84,6 @@ class FileHandler extends Component {
   }
 }
 
-
 //Connect the FileHandler Component to react dnd (which is basically a redux store)
 FileHandler = DropTarget(props => props.accepts, boxTarget, (connect, monitor) => ({
 	connectDropTarget: connect.dropTarget(),
@@ -93,7 +92,6 @@ FileHandler = DropTarget(props => props.accepts, boxTarget, (connect, monitor) =
 }))(FileHandler)
 //returns a collect function
 
-//Connect the connected FileHandler to the app's redux store (should this be done here, or in the container and passed as props?)
 FileHandler = connect(mapStateToProps)(FileHandler); 
 
 export default FileHandler

--- a/src/components/FileHandler.js
+++ b/src/components/FileHandler.js
@@ -35,6 +35,15 @@ const boxTarget = {
 	},
 }
 
+const mapStateToProps = (state) => {
+  return {
+    cardTitle: state.fileHandler.displayProps.cardTitle,
+    cardIcon : state.fileHandler.displayProps.cardIcon,
+    cardInfo : state.fileHandler.displayProps.cardInfo,
+    status : state.fileHandler.displayProps.status
+  }; 
+}
+
 class FileHandler extends Component {
   constructor(props) {
     super(props);
@@ -85,13 +94,6 @@ FileHandler = DropTarget(props => props.accepts, boxTarget, (connect, monitor) =
 //returns a collect function
 
 //Connect the connected FileHandler to the app's redux store (should this be done here, or in the container and passed as props?)
-FileHandler = connect((state) => {
-  return {
-    cardTitle: state.fileHandler.displayProps.cardTitle,
-    cardIcon : state.fileHandler.displayProps.cardIcon,
-    cardInfo : state.fileHandler.displayProps.cardInfo,
-    status : state.fileHandler.displayProps.status
-  };
-})(FileHandler); 
+FileHandler = connect(mapStateToProps)(FileHandler); 
 
-export default FileHandler;
+export default FileHandler

--- a/src/components/FileHandlerContainer.js
+++ b/src/components/FileHandlerContainer.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react'
-import store from '../setupStore'
+import { connect } from 'react-redux'
+import { bindActionCreators } from 'redux'
 import { DragDropContext, DragDropContextProvider } from 'react-dnd'
 import HTML5Backend, { NativeTypes } from 'react-dnd-html5-backend'
 import FileHandler from './FileHandler'
@@ -8,7 +9,21 @@ import {parseData, now} from '../internal/Parser'
 
 import './FileHandlerContainer.css';
 
-// I probably need to connect() this to the redux store, not the presentiational component.
+const mapDispatchToProps = (dispatch) => {
+    return {
+      pushData: data => {
+        dispatch({
+          type: 'PUSH_DATA',
+          data
+        })
+      },
+      dropFile: () => {
+          dispatch({
+              type: 'DROP_FILE'
+          })
+      }
+    }
+}
 
 class FileHandlerContainer extends Component {
     constructor(props) {
@@ -29,7 +44,7 @@ class FileHandlerContainer extends Component {
         let end = now();
         console.log("Time to clean: ", (end-start || "(Unknown; your browser does not support the Performance API)"), "ms");
         console.log(cleanData)
-        store.dispatch(fileHandlerActions.pushData(cleanData))
+        this.props.pushData(cleanData)
         //this.setState({cleanData : cleanData})
     }
     //This is a really big function - I'll make it smaller later.
@@ -44,7 +59,7 @@ class FileHandlerContainer extends Component {
                 // log file that was passed
                 console.log(droppedFiles[0])
                 // update the state of the ui
-                store.dispatch(fileHandlerActions.dropFile())
+                this.props.dropFile()
                 // update state with dropped file
                 this.setState({ droppedFiles })
                 // parse
@@ -98,4 +113,6 @@ class FileHandlerContainer extends Component {
     }
 }
 
-export default DragDropContext(HTML5Backend)(FileHandlerContainer);
+FileHandlerContainer = DragDropContext(HTML5Backend)(FileHandlerContainer);
+FileHandlerContainer = connect(null,mapDispatchToProps)(FileHandlerContainer)
+export default FileHandlerContainer


### PR DESCRIPTION
 - Make redux connect() calls clearer by using mapStateToProps and mapDispatchToProps.
 - Aim to make a clear separation between redux architecture and react architecture 